### PR TITLE
Add toprank to Claude Code CLI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ Unleash Claude's raw power directly in your terminal. Search million-line
 codebases instantly. Turn hours-long workflows into a single command. Your
 tools. Your workflow. Your codebase, evolving at thought speed.
 
+#### [Toprank](https://github.com/nowork-studio/toprank)
+
+Toprank is an open-source Claude Code plugin for SEO, Google Ads, content writing, CMS setup, and search optimization workflows. It packages reusable marketing and growth skills so teams can run keyword research, landing page optimization, ad copy generation, and structured SEO execution directly inside Claude Code.
+
 #### [Gemini CLI](https://github.com/google-gemini/gemini-cli)
 
 Gemini CLI empowers developers to query and edit large codebases beyond the 1M


### PR DESCRIPTION
Adds `nowork-studio/toprank` under CLI Tools > Claude Code.

`toprank` is an open-source Claude Code plugin for SEO, Google Ads, content writing, and CMS optimization workflows.

## Credibility
`nowork-studio/toprank` currently has **115 GitHub stars** and is MIT licensed.

## Why it fits
`toprank` is a GitHub-distributed Claude Code plugin with a concrete workflow surface, so it fits this curated directory of AI-powered coding tools and plugins.

Source: https://github.com/nowork-studio/toprank