### PR TITLE
Add SwarmVault to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,10 @@ A hosted MCP server for searching scientific papers with full-text experimental 
 
 Open-source browser extension and MCP server for annotation-first UI pair programming. Annotate any webpage and let AI coding agents (Claude Code, Cursor, Windsurf) understand UI context through 8 MCP tools. Perfect for vibe coding workflows where you point at UI elements and let AI fix them.
 
+### [SwarmVault](https://github.com/swarmclawai/swarmvault)
+
+Local-first RAG knowledge vault and MCP server. Compiles raw sources (books, notes, transcripts, exports, datasets, slide decks, files, URLs, code) into a durable markdown wiki with a knowledge graph and a hybrid SQLite FTS plus embeddings index. The bundled MCP server (`npx -y @swarmvaultai/cli mcp`) exposes page search, page reads, source listing, query, ingest, compile, and lint tools. Designed to cut token usage in vibe coding workflows by serving compact wiki summaries instead of raw source files. Works with Claude Code, Codex, OpenCode, Cursor, and any MCP client. MIT, runs entirely on your machine.
+
 ## Agents
 
 > Development frameworks and SDKs for building AI agents and autonomous coding assistants.


### PR DESCRIPTION
Adds [SwarmVault](https://github.com/swarmclawai/swarmvault) under MCP Servers.

SwarmVault is a local-first RAG knowledge vault with a built-in MCP server. It compiles raw sources (books, notes, transcripts, exports, datasets, slide decks, files, URLs, code) into a durable markdown wiki with a knowledge graph and a hybrid SQLite FTS plus embeddings index.

Why this fits vibe coding: in long sessions, agents like Claude Code and Codex burn tokens re-reading source files. SwarmVault compiles those sources into compact wiki pages once, then the MCP server (`npx -y @swarmvaultai/cli mcp`) hands the agent only the relevant chunks via page search and query tools. Practical token savings come from replacing repeated full-file reads with targeted retrieval.

- Repo: https://github.com/swarmclawai/swarmvault
- CLI on npm: https://www.npmjs.com/package/@swarmvaultai/cli
- Website: https://swarmvault.ai
- License: MIT