### PR TITLE
Add Parallel Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A Curated List of Vibe Coding Open-Source Projects, Tools, and Learning Resource
       - [RA.Aid](#raaid)
       - [CodeSelect](#codeselect)
       - [OpenAI Codex](#openai-codex)
+      - [Parallel Code](#parallel-code)
       - [Qwen Code](#qwen-code)
       - [Amp](#amp)
       - [Aider](#aider)
@@ -207,6 +208,10 @@ CodeSelect is a lightweight CLI tool that helps developers share code with AI as
 #### [OpenAI Codex](https://github.com/openai/codex)
 
 OpenAI Codex CLI is a lightweight coding agent that runs locally in your terminal. It provides intelligent coding assistance with features like autonomous code generation, debugging, refactoring, and testing. Codex offers three levels of autonomy from read-only to full write access, runs in a secure sandbox environment, supports both interactive and non-interactive modes, integrates with ChatGPT plans for usage-based billing, and can work with open-source models via Ollama. With 34.5k+ stars, it's one of the most popular AI coding agents available.
+
+#### [Parallel Code](https://github.com/johannesjo/parallel-code)
+
+Parallel Code is an open-source desktop app for running multiple terminal-based coding agents in parallel. It supports Claude Code, Codex CLI, Gemini CLI, and other CLI agents, creates an isolated git branch and worktree per task, and includes terminal panes, diff review, merge controls, and optional local remote monitoring.
 
 #### [Qwen Code](https://github.com/QwenLM/qwen-code)
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A Curated List of Vibe Coding Open-Source Projects, Tools, and Learning Resource
       - [CodeSelect](#codeselect)
       - [DevProjex](#devprojex)
       - [OpenAI Codex](#openai-codex)
+      - [Parallel Code](#parallel-code)
       - [Qwen Code](#qwen-code)
       - [Amp](#amp)
       - [Aider](#aider)
@@ -234,6 +235,10 @@ OpenAI Codex CLI is a lightweight coding agent that runs locally in your termina
 codex-profiles is a small Bash utility for switching Codex CLI and Codex Desktop
 accounts with isolated `CODEX_HOME` profiles. It keeps auth, config, sessions,
 connectors, logs, and local Codex state separated without copying token files.
+
+#### [Parallel Code](https://github.com/johannesjo/parallel-code)
+
+Parallel Code is an open-source desktop app for running multiple terminal-based coding agents in parallel. It supports Claude Code, Codex CLI, Gemini CLI, and other CLI agents, creates an isolated git branch and worktree per task, and includes terminal panes, diff review, merge controls, and optional local remote monitoring.
 
 #### [Qwen Code](https://github.com/QwenLM/qwen-code)
 


### PR DESCRIPTION
Adds Parallel Code to the CLI tools section.

Parallel Code is a free, MIT-licensed desktop app for running terminal-based coding agents such as Claude Code, Codex CLI, and Gemini CLI in parallel. Each task runs in its own Git branch and worktree, with terminal panes, diff review, and merge controls.