### PR TITLE
Add Agent FM

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,13 @@ MoonshotAI's agent development framework (Kosong means "empty" or "void" in Mala
 
 > Essential tools that enhance your vibe coding workflow.
 
+### [Agent FM](https://github.com/agentfm-ai/agent-fm)
+
+Agent FM is a local, open-source macOS companion for Claude Code and Codex
+sessions. It turns active local sessions into narrated stations with Global
+Mix, blocker alerts, and BYOK Gemini/OpenAI narration, so developers can follow
+parallel agents without reading every terminal.
+
 ### [Vercel](https://vercel.com)
 
 Vercel is a cloud platform for static sites and Serverless Functions that fits

--- a/README.md
+++ b/README.md
@@ -687,6 +687,13 @@ MoonshotAI's agent development framework (Kosong means "empty" or "void" in Mala
 
 Open-source tool for cleaning AI-generated pixel art for game development.
 
+### [Agent FM](https://github.com/agentfm-ai/agent-fm)
+
+Agent FM is a local, open-source macOS companion for Claude Code and Codex
+sessions. It turns active local sessions into narrated stations with Global
+Mix, blocker alerts, and BYOK Gemini/OpenAI narration, so developers can follow
+parallel agents without reading every terminal.
+
 ### [Vercel](https://vercel.com)
 
 Vercel is a cloud platform for static sites and Serverless Functions that fits


### PR DESCRIPTION
Adds Agent FM, a local/open-source macOS companion for Claude Code and Codex sessions.

Agent FM does not replace the coding agent runtime. It turns useful local session activity — progress, blockers, decisions, errors, and attention requests — into live narration. Developers can tune into one agent or listen to a Global Mix across active agents.

I added it under Supporting Tools because it fits as a companion/awareness tool for developers running multiple local coding agents.