### PR TITLE
Add vibeprompt to Guides & Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,6 +715,10 @@ Dive deep into the Model Context Protocol (MCP) with this comprehensive 1-hour 3
 
 Practical breakdown of the vibe coding approach for developers actually shipping things. Covers what vibe coding is, how to approach AI-assisted development without losing control of your codebase, and honest comparisons of the tools (Cursor, Lovable, ElevenLabs, and more) that matter for real projects. No hype — just what works.
 
+#### [vibeprompt — the vibe coding cookbook](https://vibeprompt.tech)
+
+Free, open-source resource for vibe coders. Bundles a 10-step interactive workflow (from idea to shipped), 56 battle-tested prompts grouped by stage, 17 long-form articles with real receipts from shipped apps, 46 field-tested fixes for problems indie devs hit (security, conversion, burnout), and an interactive AGENTS.md + PRD generator. MIT licensed, no sign-up, runs in the browser.
+
 ## Repo Status
 
 ![Alt](https://repobeats.axiom.co/api/embed/4b9660ab5b37e6ebaa2f2e036eea18e08787410d.svg "Repobeats analytics image")

--- a/README.md
+++ b/README.md
@@ -818,6 +818,10 @@ Free browser tool for turning a vague Codex CLI project goal into a scoped first
 
 Practical knowledge base for AI-assisted development with guides, a glossary, jobs, and a public MCP endpoint for agent-readable site context.
 
+#### [vibeprompt — the vibe coding cookbook](https://vibeprompt.tech)
+
+Free, open-source resource for vibe coders. Bundles a 10-step interactive workflow (from idea to shipped), 56 battle-tested prompts grouped by stage, 17 long-form articles with real receipts from shipped apps, 46 field-tested fixes for problems indie devs hit (security, conversion, burnout), and an interactive AGENTS.md + PRD generator. MIT licensed, no sign-up, runs in the browser.
+
 ### Handbooks
 
 > Book-length guides that go deep on building production software with AI.


### PR DESCRIPTION
Adds [vibeprompt](https://vibeprompt.tech) to Learning Resources → Guides & Resources.

**What it is:** a free, open-source, web-based resource for vibe coders. Bundles:
- 10-step interactive workflow (localStorage-saved checklists) from idea to shipped
- 56 battle-tested prompts grouped by workflow stage
- 17 long-form articles with real receipts from shipped apps
- 46 field-tested fixes for problems indie devs hit (security, conversion, burnout, etc.)
- Interactive AGENTS.md + PRD generator — fill in fields, get ready-to-use markdown

**Why it fits Guides & Resources:** vibeprompt is editorial + methodology (not a tool itself). It pairs with the CodingButVibes guide already in this section as the "practical playbook" for vibe coders shipping real projects.

MIT licensed, source: github.com/dotsystemsdevs/vibe-prompt.

Thanks for maintaining the list! 🙏