### PR TITLE
feat: add TWZRD Agent Intel MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,6 +586,12 @@ Open-source browser extension and MCP server for annotation-first UI pair progra
 
 Local-first RAG knowledge vault and MCP server. Compiles raw sources (books, notes, transcripts, exports, datasets, slide decks, files, URLs, code) into a durable markdown wiki with a knowledge graph and a hybrid SQLite FTS plus embeddings index. The bundled MCP server (`npx -y @swarmvaultai/cli mcp`) exposes page search, page reads, source listing, query, ingest, compile, and lint tools. Designed to cut token usage in vibe coding workflows by serving compact wiki summaries instead of raw source files. Works with Claude Code, Codex, OpenCode, Cursor, and any MCP client. MIT, runs entirely on your machine.
 
+### [TWZRD Agent Intel](https://intel.twzrd.xyz)
+
+Trust scoring and identity verification MCP server for AI agents on Solana. Provides wallet reputation
+scoring and preflight checks before x402 micropayments. Zero-install streamable-HTTP transport:
+`{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`. Tools include
+`score_agent(wallet)`, `preflight_check(wallet)` (free), and `get_trust_receipt(wallet)` (x402 paid).
 ## Agents
 
 > Development frameworks and SDKs for building AI agents and autonomous coding assistants.


### PR DESCRIPTION
## Add TWZRD Agent Intel to MCP Servers section

[TWZRD Agent Intel](https://intel.twzrd.xyz) is a trust scoring MCP server for AI agents on Solana.

- **Purpose**: Verify agent wallet identity before x402 micropayments
- **Tools**: `score_agent(wallet)`, `preflight_check(wallet)` (free), `get_trust_receipt(wallet)` (paid)
- **Transport**: Streamable-HTTP, zero-install
- **Config**: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`

Fits in the MCP Servers section alongside Notion, GitHub, and other specialized MCP servers.