### PR TITLE
Add Playcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ A Curated List of Vibe Coding Open-Source Projects, Tools, and Learning Resource
       - [Tempo.new](#temponew)
       - [Softgen](#softgen)
       - [HeyBoss](#heyboss)
+      - [Playcode](#playcode)
       - [Creatr](#creatr)
       - [Rork](#rork)
       - [Napkins.dev](#napkinsdev)
@@ -374,6 +375,10 @@ Softgen is an AI web app builder that turns your ideas into stunning web applica
 #### [HeyBoss](https://www.heyboss.xyz)
 
 HeyBoss AI is the easiest no-code AI builder for sites and apps where everyone can vibe code. Create apps and websites by simply chatting with AI. Features include built-in database, AI app store, payment acceptance, visual editor, and SEO optimization. Free plan available with community support.
+
+#### [Playcode](https://playcode.io/ai-website-builder)
+
+Playcode is an AI website and app builder for creating hosted sites and web apps from natural-language prompts. It combines chat-based generation, visual editing, one-click publishing, custom domains, and Playcode Cloud hosting so users can build and update projects directly in the browser.
 
 #### [Creatr](https://getcreatr.com)
 


### PR DESCRIPTION
Adds Playcode to the Web-based IDEs section.

Why it fits: Playcode lets users create hosted websites and web apps from natural-language prompts in the browser, with visual editing, publishing, custom domains, and built-in hosting. That puts it next to tools already listed in this section, such as Bolt.new, Create.xyz, HeyBoss, Rocket.new, and Lazy AI.

Changed only the README entry and table of contents.
