### PR TITLE
Add VibeKit.bot to Mobile-first tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,17 @@ your fully native iOS app running on your phone. You can then share this app
 with your friends in 1 click, and they can use the app without downloading
 anything.
 
+#### [VibeKit.bot](https://vibekit.bot)
+
+VibeKit gives every app its own persistent AI coding agent that builds it,
+hosts it on a live web domain, and keeps improving it — driven entirely from
+your phone (native iOS app) or the CLI. Unlike one-shot generators you babysit
+at a laptop, the agent keeps working after the first prototype: there's no
+machine to keep awake and it survives a dropped connection, so you can kick off
+a change and close the app. Bring your own Claude or OpenAI key, or pay as you
+go — no bundled-credit lock-in. Each app ships on a live domain with an optional
+database add-on.
+
 ## Development Standards
 
 > Open standards and formats for building interoperable AI coding agents and applications.


### PR DESCRIPTION
Adds **VibeKit.bot** to the *Mobile-first tools* section — it fits the "create apps directly on your phone" theme alongside vibecode.

VibeKit gives every app its own persistent AI coding agent that builds, hosts, and keeps improving it, driven from a native iOS app or the CLI. It's distinct from vibecode: rather than one-shot generating a native app to share, VibeKit's per-app agent keeps working after the first prototype (survives a dropped connection, no machine to keep awake), ships each app on a live web domain, and is BYOK (Claude/OpenAI) or pay-as-you-go.

- Website: https://vibekit.bot
- Format-matched the existing `#### [name](url)` + description-paragraph style.
- Listed as "VibeKit.bot" to disambiguate from the unrelated `superagent-ai/vibekit` SDK.

Disclosure: I'm the maker of VibeKit.bot.