### PR TITLE
Add BitFun to Standalone IDEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A Curated List of Vibe Coding Open-Source Projects, Tools, and Learning Resource
       - [OpenPaw](#openpaw)
     - [Standalone IDEs](#standalone-ides)
       - [Cursor](#cursor)
+      - [BitFun](#bitfun)
       - [Trae](#trae)
       - [Qoder](#qoder)
       - [Windsurf Editor](#windsurf-editor)
@@ -235,6 +236,10 @@ The hangover cure for vibe coding. A language-agnostic CLI tool that scans AI-ge
 #### [Cursor](https://www.cursor.com/)
 
 Cursor is the AI code editor used by millions of engineers worldwide, built to make you extraordinarily productive. Powered by a mix of purpose-built and frontier models, Cursor features intelligent tab completion that predicts your next edit, natural language code editing for updating entire classes or functions with simple prompts, and deep codebase understanding that lets you get answers from your codebase or refer to files and docs instantly. With seamless VS Code compatibility (import all extensions, themes, and keybindings in one click), privacy options including SOC 2 certification, and trusted by engineers at Samsung, Stripe, OpenAI, and other world-class companies, Cursor represents the best way to code with AI.
+
+#### [BitFun](https://github.com/GCWing/BitFun)
+
+BitFun is an open-source cross-platform desktop AI agent built with a Rust runtime and React interface. It works in real Git repositories to plan, edit, test, review, and commit code, and can also operate terminals, browsers, desktop applications, filesystems, and remote workspaces. BitFun supports user-selected model providers, MCP, Skills, Codex-compatible Hooks, custom Agents, and task-specific Mini Apps whose interfaces stay bound to the conversation state. It runs on macOS, Windows, and Linux and includes an optional self-hosted relay for encrypted cross-device session control.
 
 #### [Trae](https://www.trae.com.cn/home)
 


### PR DESCRIPTION
## Summary

Adds [BitFun](https://github.com/GCWing/BitFun) to **Development Toolkits → Standalone IDEs** and updates the table of contents.

BitFun is an open-source cross-platform desktop AI agent for planning, editing, testing, reviewing, and committing code in real repositories. It also supports terminal, browser, desktop-app, filesystem, and remote-workspace execution, with MCP, Skills, Hooks, custom Agents, and task-specific Mini Apps.

## Validation

- Confirmed there is no existing BitFun entry or public submission
- Ran `node scripts/parse-readme.js` successfully; it parsed 103 items
- `git diff --check` passes

## Disclosure

This is a project self-submission made on behalf of BitFun.
