### PR TITLE
Add agent-qa to CLI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ A Curated List of Vibe Coding Open-Source Projects, Tools, and Learning Resource
 
 > Integrate AI directly into your terminal.
 
+#### [agent-qa](https://github.com/vostride/agent-qa)
+
+agent-qa is the self-improving QA agent for software teams. It runs natural-language web and mobile tests from the command line, learns from prior runs, heals around UI drift, and exposes MCP tools and skills for coding-agent workflows.
+
 #### [Claude Code](https://www.anthropic.com/claude-code)
 
 Unleash Claude's raw power directly in your terminal. Search million-line


### PR DESCRIPTION
## Summary

Adds agent-qa to **Command Line Interface (CLI) Tools**.

agent-qa is the self-improving QA agent for software teams. It runs natural-language web and mobile tests from the terminal, learns from prior executions, heals around UI drift, and exposes MCP tools and skills for coding-agent workflows.

## Validation

- Preserved the section's heading-plus-description format.
- Verified the public repository URL.
- Confirmed the project was not already listed.
- `git diff --check` passes.

Project disclosure: this submission is for agent-qa itself.
