### PR TITLE
Add Sillage

### DIFF
--- a/contents/harnesses/mobile-harnesses/sillage.md
+++ b/contents/harnesses/mobile-harnesses/sillage.md
@@ -1,0 +1,6 @@
+---
+name: "Sillage"
+link: "https://github.com/MarlBurroW/sillage"
+---
+
+Sillage is a self-hosted, MIT-licensed, mobile-first web UI that drives the native Claude Code and Codex CLIs running on your own machine (the official agent harnesses, without a terminal). Sessions outlive the client thanks to a server-side event journal, so you can kick off work from your phone and close the tab. It ships full-text search over every conversation, a message queue, an IDE panel (file explorer, editor, diffs, terminal), git worktrees, a board the agents read through its own MCP server, and an installable PWA with push. Runs as a single Docker container on port 7317.


### PR DESCRIPTION
Adds Sillage under Harnesses > Mobile Harnesses (new file contents/harnesses/mobile-harnesses/sillage.md, following the one-file-per-tool structure).

Disclosure: I am the author of Sillage.

Sillage is a self-hosted, MIT-licensed, mobile-first web UI that drives the native Claude Code and Codex CLIs on your own machine (the official agent harnesses, without a terminal). Sessions outlive the client via a server-side event journal so you can start work from your phone and close the tab; full-text search over every conversation, a message queue, an IDE panel (file explorer, editor, diffs, terminal), git worktrees, a board the agents read through its own MCP server, and an installable PWA with push. Single Docker container on port 7317.

Repo: https://github.com/MarlBurroW/sillage