### PR TITLE
Add Vibe-Coding Prompt Template to harness-extensions/skills

### DIFF
--- a/contents/harness-extensions/skills/vibe-coding-prompt-template.md
+++ b/contents/harness-extensions/skills/vibe-coding-prompt-template.md
@@ -1,0 +1,6 @@
+---
+name: Vibe-Coding Prompt Template
+link: https://github.com/KhazP/vibe-coding-prompt-template
+command: vibeworkflow
+---
+Six planning skills that take an idea through deep research, a PRD, and a technical design, then write the AGENTS.md and agent_docs/ files a coding agent builds from.


### PR DESCRIPTION
Adds one file, `contents/harness-extensions/skills/vibe-coding-prompt-template.md`, following the format in `Adding a Tool`:

```markdown
---
name: Vibe-Coding Prompt Template
link: https://github.com/KhazP/vibe-coding-prompt-template
command: vibeworkflow
---
Six planning skills that take an idea through deep research, a PRD, and a technical design, then write the AGENTS.md and agent_docs/ files a coding agent builds from.
```

**Disclosure:** these are my own skills.

Filed under harness-extensions/skills as reusable agent skills rather than a harness of its own — the six skills (`vibe-workflow`, `vibe-research`, `vibe-prd`, `vibe-techdesign`, `vibe-agents`, `vibe-build`) plug into Claude Code and are installable individually with `npx skills add`. The `command` field is the npm CLI that installs them and drives the same stages as an interview.

New file only, no existing entries touched, per the note about preferring separate files. MIT licensed, 2.8k stars, actively maintained.
