### PR TITLE
Add viberank to Agent Observability

### DIFF
--- a/contents/supporting-tools/observability/viberank.md
+++ b/contents/supporting-tools/observability/viberank.md
@@ -1,0 +1,13 @@
+---
+name: "viberank"
+link: "https://viberank.app"
+command: "npx viberank-cli"
+---
+
+viberank is a public leaderboard and open dataset for AI coding spend. It reads the
+same local ccusage session data that other observability tools use — across Claude
+Code, Codex, Gemini CLI, Copilot, OpenCode and more — and aggregates it into a
+comparison rather than a local dashboard, so you can see whether your usage is
+normal rather than just what it was. Per-tool boards, verified GitHub profiles,
+README badges, and daily autosubmit. The aggregate spend distribution is published
+under CC BY 4.0 through a free JSON API.


### PR DESCRIPTION
Adds one new file under **Supporting Tools → Agent Observability**, following the `Adding a Tool` guidance (separate file, no edits to existing ones).

`contents/supporting-tools/observability/viberank.md`

The existing entries in this category answer "what did my session do" locally. viberank answers the adjacent question — "is this normal" — by aggregating the same ccusage session data into a public comparison and publishing the resulting spend distribution as open data.

1,126 developers and ~$10.9M in API-equivalent spend tracked across 17 agents. MIT licensed, `viberank-cli` on npm, and listed on ccusage's own community projects page.

**Disclosure: I maintain viberank.** Happy for the description to be trimmed or the entry dropped.
